### PR TITLE
Fix on page service level errors in Drupal log

### DIFF
--- a/backend/src/modules/nc_system/src/Entity/Node/ServiceLandingPage.php
+++ b/backend/src/modules/nc_system/src/Entity/Node/ServiceLandingPage.php
@@ -75,10 +75,10 @@ class ServiceLandingPage extends Content implements GraphQLEntityFieldResolver {
    * This function returns an array containing information about Service Alerts
    */
   public function getServicePageAlerts() {
-    $active = $this->get('field_enable_alert')->getValue()[0]['value'];
+    $active = empty($this->get('field_enable_alert')->getValue()) ? FALSE: $this->get('field_enable_alert')->getValue()[0]['value'];
     $expired = false;
 
-    $expiration = $this->get('field_alert_expiration_date')->getValue()[0]['value'];
+    $expiration = empty($this->get('field_alert_expiration_date')->getValue()) ? FALSE : $this->get('field_alert_expiration_date')->getValue()[0]['value'];
     $alertItem = ['title' => ''];
 
     if($expiration) {

--- a/backend/src/modules/nc_system/src/Entity/Node/ServiceLandingPage.php
+++ b/backend/src/modules/nc_system/src/Entity/Node/ServiceLandingPage.php
@@ -75,7 +75,7 @@ class ServiceLandingPage extends Content implements GraphQLEntityFieldResolver {
    * This function returns an array containing information about Service Alerts
    */
   public function getServicePageAlerts() {
-    $active = empty($this->get('field_enable_alert')->getValue()) ? FALSE: $this->get('field_enable_alert')->getValue()[0]['value'];
+    $active = empty($this->get('field_enable_alert')->getValue()) ? FALSE : $this->get('field_enable_alert')->getValue()[0]['value'];
     $expired = false;
 
     $expiration = empty($this->get('field_alert_expiration_date')->getValue()) ? FALSE : $this->get('field_alert_expiration_date')->getValue()[0]['value'];

--- a/backend/src/modules/nc_system/src/Entity/Node/ServicePage.php
+++ b/backend/src/modules/nc_system/src/Entity/Node/ServicePage.php
@@ -99,7 +99,7 @@ class ServicePage extends Content implements GraphQLEntityFieldResolver {
     } while (!is_null($parent));
 
     if($parent && $parent->isPublished()) {
-      $active = empty($parent->get('field_enable_alert')->getValue()) ? FALSE: $parent->get('field_enable_alert')->getValue()[0]['value'];
+      $active = empty($parent->get('field_enable_alert')->getValue()) ? FALSE : $parent->get('field_enable_alert')->getValue()[0]['value'];
       $expired = false;
 
       $expiration = empty($parent->get('field_alert_expiration_date')->getValue()) ? FALSE : $parent->get('field_alert_expiration_date')->getValue()[0]['value'];

--- a/backend/src/modules/nc_system/src/Entity/Node/ServicePage.php
+++ b/backend/src/modules/nc_system/src/Entity/Node/ServicePage.php
@@ -6,6 +6,7 @@ use Drupal\nc_system\Entity\Paragraph\CouncilSignposting;
 use Drupal\nc_system\Entity\Paragraph\Section;
 use Drupal\nc_system\GraphQLFieldResolver;
 use Drupal\nc_system\Entity\GraphQLEntityFieldResolver;
+use Drupal\Core\Datetime\DrupalDateTime;
 use phpDocumentor\Reflection\Types\Boolean;
 
 
@@ -98,10 +99,10 @@ class ServicePage extends Content implements GraphQLEntityFieldResolver {
     } while (!is_null($parent));
 
     if($parent && $parent->isPublished()) {
-      $active = $parent->get('field_enable_alert')->getValue()[0]['value'];
+      $active = empty($parent->get('field_enable_alert')->getValue()) ? FALSE: $parent->get('field_enable_alert')->getValue()[0]['value'];
       $expired = false;
 
-      $expiration = $parent->get('field_alert_expiration_date')->getValue()[0]['value'];
+      $expiration = empty($parent->get('field_alert_expiration_date')->getValue()) ? FALSE : $parent->get('field_alert_expiration_date')->getValue()[0]['value'];
 
       if($expiration) {
         $currentTime = new DrupalDateTime('now');


### PR DESCRIPTION
Fix an on page service level not being set causing notices in the error log and missing use statement from the ServicePage.php file